### PR TITLE
Add support for multiple loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ yarn add spotify-smart-playlists
 
 ```javascript
 const { SmartPlaylistsGenerator, PlaylistLoader } = require('spotify-smart-playlists')
-const { compose, reverse, take } = require('ramda')
+const { compose, reverse, take, flatten } = require('ramda')
 
 // Initiate a new SmartPlaylistsGenerator instance. Please take a look at
 // Spotify's documentation to learn how to get the required params:
@@ -25,15 +25,15 @@ const smartPlaylists = new SmartPlaylistsGenerator({
   refreshToken: 'your refresh token'
 })
 
-// In this example we that one playlist as input, reverse the order, and take the
+// In this example we take one playlist as input, reverse the order, and take the
 // first 20 tracks (which are actually the 20 last tracks, since the order is
 // reversed)
 const loader = new PlaylistLoader('bramschulting', '4tWeRdIYH4ZPo5vvJIPJFm')
 const outputPlaylist = { id: '7a81cTH5K8MUF6geWYZahA', userId: 'bramschulting' }
-const generator = compose(take(20), reverse)
+const generator = compose(take(20), reverse, flatten)
 
 // Add the playlist generator to our instance
-smartPlaylists.addPlaylist(loader, outputPlaylist, generator)
+smartPlaylists.addPlaylist([loader], outputPlaylist, generator)
 
 // Run your playlist generator(s)
 smartPlaylists.generatePlaylists()

--- a/classes/SmartPlaylistsGenerator.js
+++ b/classes/SmartPlaylistsGenerator.js
@@ -3,6 +3,10 @@ const spotifyApiHelper = require('../helpers/spotifyApi')
 const { map } = require('ramda')
 const { trackUri } = require('../selectors/track')
 
+function loadLoaders (apiInstance, loaders) {
+  return Promise.all(loaders.map(loader => loader.getTracks(apiInstance)))
+}
+
 class SmartPlaylistsGenerator {
   constructor (options) {
     // TODO: Validate options
@@ -11,11 +15,11 @@ class SmartPlaylistsGenerator {
     this.playlistGenerators = []
   }
 
-  addPlaylist (loader, outputPlaylist, generator) {
+  addPlaylist (loaders, outputPlaylist, generator) {
     // TODO: Validate input
 
     this.playlistGenerators.push({
-      loader,
+      loaders,
       outputPlaylist,
       generator
     })
@@ -31,8 +35,7 @@ class SmartPlaylistsGenerator {
         // Generate each playlist
         const generatorPromises = this.playlistGenerators.map(
           playlistGenerator =>
-            playlistGenerator.loader
-              .getTracks(apiInstance)
+            loadLoaders(apiInstance, playlistGenerator.loaders)
               .then(playlistGenerator.generator)
               .then(map(trackUri))
               .then(trackUris =>

--- a/classes/__specs__/SmartPlaylistsGenerator.spec.js
+++ b/classes/__specs__/SmartPlaylistsGenerator.spec.js
@@ -22,15 +22,15 @@ describe('SmartPlaylistsGenerator', () => {
 
   describe('addPlaylist', () => {
     it('should store a playlist generator', () => {
-      const loader = 'some loader'
+      const loaders = ['some loader']
       const outputPlaylist = 'some output playlist'
       const generatorFunction = 'some generator function'
 
       const generator = new SmartPlaylistsGenerator()
-      generator.addPlaylist(loader, outputPlaylist, generatorFunction)
+      generator.addPlaylist(loaders, outputPlaylist, generatorFunction)
 
       expect(generator.playlistGenerators).toHaveLength(1)
-      expect(generator.playlistGenerators[0].loader).toEqual(loader)
+      expect(generator.playlistGenerators[0].loaders).toEqual(loaders)
       expect(generator.playlistGenerators[0].outputPlaylist).toEqual(
         outputPlaylist
       )
@@ -60,26 +60,33 @@ describe('SmartPlaylistsGenerator', () => {
     })
   })
 
-  it('should get the input tracks for each playlist', () => {
+  it('should get the tracks of all loaders for each playlist', () => {
     // Arrange
     const apiInstance = 'apiInstance'
     authorizedInstanceHelper.getAuthorizedInstance = () =>
       Promise.resolve(apiInstance)
 
     const generator = new SmartPlaylistsGenerator()
-    const loader = {
+    const loader1 = {
       getTracks: jest.fn(() => Promise.reject(new Error()))
     }
+    const loader2 = {
+      getTracks: jest.fn(() => Promise.reject(new Error()))
+    }
+    const loaders = [loader1, loader2]
     const outputPlaylist = 'some output playlist'
     const generatorFunction = 'some generator function'
 
-    generator.addPlaylist(loader, outputPlaylist, generatorFunction)
+    generator.addPlaylist(loaders, outputPlaylist, generatorFunction)
 
     // Act
     return generator.generatePlaylists().catch(() => {
       // Assert
-      expect(loader.getTracks).toHaveBeenCalledTimes(1)
-      expect(loader.getTracks).toHaveBeenCalledWith(apiInstance)
+      expect(loader1.getTracks).toHaveBeenCalledTimes(1)
+      expect(loader1.getTracks).toHaveBeenCalledWith(apiInstance)
+
+      expect(loader2.getTracks).toHaveBeenCalledTimes(1)
+      expect(loader2.getTracks).toHaveBeenCalledWith(apiInstance)
     })
   })
 
@@ -98,13 +105,13 @@ describe('SmartPlaylistsGenerator', () => {
     const outputPlaylist = 'some output playlist'
     const generatorFunction = jest.fn()
 
-    generator.addPlaylist(loader, outputPlaylist, generatorFunction)
+    generator.addPlaylist([loader], outputPlaylist, generatorFunction)
 
     // Act
     return generator.generatePlaylists().catch(() => {
       // Assert
       expect(generatorFunction).toHaveBeenCalledTimes(1)
-      expect(generatorFunction).toHaveBeenCalledWith(inputPlaylistTracks)
+      expect(generatorFunction).toHaveBeenCalledWith([inputPlaylistTracks])
     })
   })
 
@@ -124,9 +131,9 @@ describe('SmartPlaylistsGenerator', () => {
       userId: 'output-userId',
       id: 'output-id'
     }
-    const generatorFunction = jest.fn(inputTracks => inputTracks)
+    const generatorFunction = jest.fn(loaderResults => loaderResults[0])
 
-    generator.addPlaylist(loader, outputPlaylist, generatorFunction)
+    generator.addPlaylist([loader], outputPlaylist, generatorFunction)
 
     // Act
     return generator.generatePlaylists().then(() => {


### PR DESCRIPTION
This change makes it possible to use multiple loaders to generate a playlist.

An example of this would be to generate a playlist by merging two or more playlists.